### PR TITLE
Allow HTTPS download of code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TEST_LOCATION="http://localhost:8000/"
-LIVE_LOCATION="http://yobriefca.se/trello-cards/"
+LIVE_LOCATION="//yobriefca.se/trello-cards/"
 
 all::	dependencies
 all::	bookmarklet test-bookmarklet


### PR DESCRIPTION
Chrome complains of the bookmarklet with the following error:

```
[blocked] The page at 'https://trello.com/b/...' was loaded over HTTPS, but ran insecure content from 'http://yobriefca.se/trello-cards/trello-cards.css': this content should also be loaded over HTTPS.
```

Downloading the bookmarklet with `//yobriefca.se` instead of `http://yobriefca.se` will use HTTP/HTTPS as needed.  However, for it to work you would need to enable HTTPS on your webserver.

Right now the bookmarklet is non-functional in chrome.
